### PR TITLE
Add support for getting and setting read power levels

### DIFF
--- a/lib/tm_mercury/message.ex
+++ b/lib/tm_mercury/message.ex
@@ -41,6 +41,11 @@ defmodule TM.Mercury.Message do
     Map.put(msg, :data, mode)
   end
 
+  def decode(%Message{opcode: :get_read_tx_power} = msg) do
+    <<power :: uint16>> = msg.data
+    Map.put(msg, :data, power)
+  end
+
   def decode(%Message{opcode: :get_region} = msg) do
     <<region :: uint8>> = msg.data
     data = TM.Mercury.Protocol.Region.decode!(region)

--- a/lib/tm_mercury/protocol/command.ex
+++ b/lib/tm_mercury/protocol/command.ex
@@ -51,6 +51,10 @@ defmodule TM.Mercury.Protocol.Command do
     {:ok, Message.encode(code)}
   end
 
+  defp build_command(_rdr, {:get_read_tx_power, code}, []) do
+    {:ok, Message.encode(code)}
+  end
+
   defp build_command(_rdr, {:get_tag_protocol, code}, []) do
     {:ok, Message.encode(code)}
   end

--- a/lib/tm_mercury/protocol/command.ex
+++ b/lib/tm_mercury/protocol/command.ex
@@ -55,6 +55,10 @@ defmodule TM.Mercury.Protocol.Command do
     {:ok, Message.encode(code)}
   end
 
+  defp build_command(_rdr, {:set_read_tx_power, code}, [level]) do
+    {:ok, Message.encode(code, <<level :: uint16>>)}
+  end
+
   defp build_command(_rdr, {:get_tag_protocol, code}, []) do
     {:ok, Message.encode(code)}
   end

--- a/lib/tm_mercury/reader.ex
+++ b/lib/tm_mercury/reader.ex
@@ -117,6 +117,19 @@ defmodule TM.Mercury.Reader do
   end
 
   @doc """
+  Get the current TX power for reading tags in centi-dBm.
+
+  ## Examples
+
+      iex> TM.Mercury.Reader.get_read_tx_power(pid)
+      {:ok, 2500} # 25 dBm
+
+  """
+  def get_read_tx_power(pid) do
+    GenServer.call(pid, :get_read_tx_power)
+  end
+
+  @doc """
   Set the tag protocol used by the reader
   """
   def set_tag_protocol(pid, protocol) do

--- a/lib/tm_mercury/reader.ex
+++ b/lib/tm_mercury/reader.ex
@@ -130,6 +130,19 @@ defmodule TM.Mercury.Reader do
   end
 
   @doc """
+  Set the current TX power for reading tags in centi-dBm.
+
+  ## Examples
+
+      iex> TM.Mercury.Reader.set_read_tx_power(pid, 2500) # 25 dBm
+      :ok
+
+  """
+  def set_read_tx_power(pid, level) do
+    GenServer.call(pid, [:set_read_tx_power, level])
+  end
+
+  @doc """
   Set the tag protocol used by the reader
   """
   def set_tag_protocol(pid, protocol) do

--- a/test/reader_test.exs
+++ b/test/reader_test.exs
@@ -27,7 +27,12 @@ defmodule TM.Mercury.ReaderTest do
 
   test "Reader changes power level", context do
     {:ok, initial_cdbm} = Reader.get_read_tx_power(context.pid)
-    change_to_cdbm = min(initial_cdbm + 100, 3000)
+
+    max_power_cdbm = 3000
+    change_to_cdbm = case initial_cdbm do
+      ^max_power_cdbm -> 2000
+      _ -> min(initial_cdbm + 100, max_power_cdbm)
+    end
 
     :ok = Reader.set_read_tx_power(context.pid, change_to_cdbm)
     {:ok, changed_cdbm} = Reader.get_read_tx_power(context.pid)

--- a/test/reader_test.exs
+++ b/test/reader_test.exs
@@ -1,6 +1,5 @@
 defmodule TM.Mercury.ReaderTest do
   use ExUnit.Case, async: false
-  doctest TM.Mercury.Reader
 
   alias TM.Mercury.{Reader, ReadPlan}
 
@@ -25,5 +24,17 @@ defmodule TM.Mercury.ReaderTest do
     assert_receive {:tm_mercury, :tags, _}, 1000
     Reader.read_async_stop(context.pid)
   end
-end
 
+  test "Reader changes power level", context do
+    {:ok, initial_cdbm} = Reader.get_read_tx_power(context.pid)
+    change_to_cdbm = min(initial_cdbm + 100, 3000)
+
+    :ok = Reader.set_read_tx_power(context.pid, change_to_cdbm)
+    {:ok, changed_cdbm} = Reader.get_read_tx_power(context.pid)
+
+    # Set power level back before asserting, assuming the op is functioning correctly.
+    Reader.set_read_tx_power(context.pid, initial_cdbm)
+
+    assert changed_cdbm == change_to_cdbm
+  end
+end


### PR DESCRIPTION
I'll test this after I receive hardware.  Feel free to test with yours and merge if needed sooner.  

TODO: Add validation for limits 0-3000.  The reader probably does its own (hopefully).