### PR TITLE
Handle response from read_sync more efficiently in ReadAsyncTask

### DIFF
--- a/lib/tm_mercury/read_async_task.ex
+++ b/lib/tm_mercury/read_async_task.ex
@@ -27,16 +27,8 @@ defmodule TM.Mercury.ReadAsyncTask do
 
   defp dispatch(%{status: :running} = state) do
     try do
-      case Reader.read_sync(state.reader, state.on, state.read_plan) do
-        {:ok, tags} when length(tags) == 0 -> state
-        {:ok, tags} when length(tags) > 0 ->
-          send(state.listener, {:tm_mercury, :tags, tags})
-          :ok = Reader.clear_tag_id_buffer(state.reader)
-          state
-        {:error, :timeout} ->
-          Logger.warn("Suspending asynchronous reads due to timeout")
-          %{state | status: :suspended}
-      end
+      Reader.read_sync(state.reader, state.on, state.read_plan)
+      |> handle_read_response(state)
     catch
       :exit, reason ->
         Logger.warn("Suspending asynchronous reads due to exit reason: #{inspect reason}")
@@ -46,4 +38,24 @@ defmodule TM.Mercury.ReadAsyncTask do
 
   # noop while suspended
   defp dispatch(%{status: :suspended} = state), do: state
+
+  defp handle_read_response({:ok, []}, state) do
+    state
+  end
+
+  defp handle_read_response({:ok, tags}, state) do
+    send(state.listener, {:tm_mercury, :tags, tags})
+    :ok = Reader.clear_tag_id_buffer(state.reader)
+    state
+  end
+
+  defp handle_read_response({:error, :timeout}, state) do
+    Logger.warn("Suspending asynchronous reads due to timeout")
+    %{state | status: :suspended}
+  end
+
+  defp handle_read_response(other, state) do
+    Logger.warn("Unexpected response during async dispatch to read_sync: #{inspect other}")
+    state
+  end
 end


### PR DESCRIPTION
Per the following warning encountered:

```
==> tm_mercury
Compiling 29 files (.ex)
warning: "length(tags) == 0" is discouraged since it has to traverse the whole list to check if it is empty or not. Prefer to pattern match on an empty list or use "tags == []" as a guard
  lib/tm_mercury/read_async_task.ex:31
```